### PR TITLE
added appa-sariicon iconic font

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ A mixture of free and open source font resources.
 
 A collection for icon font resources, most of which also include SVGs, which can be used in your interface and website designs.
 
+* [Appa Sariicon](http://code.sariina.com/appa-sariicon/) [:copyright:](http://scripts.sil.org/OFL) 147 8-bit retro style webfont icons for web and mobile
 * [Batch Icons](http://adamwhitcroft.com/batch/) - [:copyright:](https://github.com/AdamWhitcroft/Batch/blob/master/License.txt) Icon set of 300+ icons, which is part of [inuit.css](https://github.com/csswizardry/inuit.css).
 * [Flaticon](http://www.flaticon.com/) - [:copyright:](http://cdn.flaticon.com/license/license.pdf) - Almost 100,000 icons in SVG, PNG, EPS, PSD and Webfont. Most icons are available under attribution.
 * [Font Awesome](http://fontawesome.io/) - [:copyright:](http://choosealicense.com/licenses/mit/) MIT licensed icon font.


### PR DESCRIPTION
Appa Sariicon is a collection of 147 webfont icons that are carefully designed for Web and Mobile