### PR TITLE
Added Supporter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,13 +291,13 @@ Please read [CONTRIBUTING](/CONTRIBUTING.md).
 * [Share on Google Plus](https://plus.google.com/share?url=https://github.com/neutraltone/awesome-stock-resources)
 * [Share on LinkedIn](https://www.linkedin.com/shareArticle?mini=true&url=https://github.com/neutraltone/awesome-stock-resources&title=Awesome%20Stock%20Resources&summary=&source=)
 
-<!--
+
 ## Donate :heart:
 
 And finally, if you appreciate this list and find it useful, please feel free to show your appreciation by donating some bitcoin to the following address:
 
-1JreNWWxZokqxaPnBJPs8ctbUx6HniGP8Z
--->
+[![Support](https://supporter.60devs.com/api/b/af5ucax531nis63r3qyqdd15n)](https://supporter.60devs.com/give/af5ucax531nis63r3qyqdd15n)
+
 ## License
 
 [![CC0](https://i.creativecommons.org/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)


### PR DESCRIPTION
Hey @neutraltone,

I have noticed that you have removed the Donate paragraph. What happened?
I am a co-author of Supporter, a service that helps open source projects on Github to accept donations, and I would like to ask you to try our badge for donations. 

[![Support](https://supporter.60devs.com/api/b/af5ucax531nis63r3qyqdd15n)](https://supporter.60devs.com/give/af5ucax531nis63r3qyqdd15n)

The badge leads to your personal payment page (built on top of PayPal) where your readers will be able to donate once you log in to our service with your GitHub account and define your PayPal email address. You can also change the text that appears on the badge in your profile. 

If you don't like the badge, let me know by closing this PR and I will delete your payment page from our web site. 

P.S. The service is free and will be free in the foreseeable future.
P.P.S. We also offer project badges and project payment pages which allow setting goals for projects and tracking the degree of the support. You can find some projects that use our service at our website if you are interested.