### PR TITLE
Fixed 301 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ These following photography resources are those who have declared their own usag
 * [Good Stock Photos](https://goodstock.photos/) - [:copyright:](https://goodstock.photos/about/) One free to use photo added everyday.
 * [ISO Republic](http://isorepublic.com/) - [:copyright:](http://isorepublic.com/terms/) ISO Republic provides exclusive free stock photos for creatives.
 * [Kaboom Pics](http://kaboompics.com/) - [:copyright:](http://kaboompics.com/terms) Great place to get breathtaking Free Pictures for business or personal projects.
-* [morgueFile](https://www.morguefile.com/archive) - [:copyright:](https://www.morguefile.com/terms) Free photo archive by creatives, for creatives.
+* [morgueFile](http://morguefile.com/archive) - [:copyright:](http://morguefile.com/terms) Free photo archive by creatives, for creatives.
 * [PhotoStockEditor](http://photostockeditor.com) - [:copyright:](http://photostockeditor.com/#small-dialog) High-resolution weekly images for Personal & Commercial use.
 * [Pic Jumbo](https://picjumbo.com/) - [:copyright:](https://picjumbo.com/faq-and-terms/) Totally free photos for your commercial & personal works.
 * [Picography](http://picography.co/) - [:copyright:](http://picography.co/terms/) Free hi-resolution photos. Use them however you like.
@@ -145,7 +145,7 @@ A collection of illustration resources which contain a mixture of historical arc
 
 A collection of resources which contain stock graphical elements which don't fit in the other sections.
 
-* [Facebook Design Resource](https://facebook.github.io/design/) - [:copyright:](https://facebook.github.io/design/disclaimer.html) A collection for design resources from Facebook including iOS9 GUI and various popular device templates.
+* [Facebook Design Resource](http://facebook.design/) - [:copyright:](http://facebook.design/disclaimer.html) A collection for design resources from Facebook including iOS9 GUI and various popular device templates.
 * [Freepik](http://www.freepik.com/) - [:copyright:](http://www.freepik.com/terms_of_use) Find free vectors, PSD, icons and photos.
 * [Logo Dust](http://logodust.com/) - [:copyright:](http://creativecommons.org/licenses/by/4.0/) Free CC Attribution 4.0 logo designs for your projects.
 * [Pixaroma](http://pixaroma.com/) - [:copyright:](http://pixaroma.com/terms-and-conditions/) original logos, icons, characters, illustrations and mobile game designs.
@@ -219,7 +219,7 @@ A collection for SVG icon resources which can be used in your interface and webs
 * [Geomicons Icons](http://geomicons.com/) - [:copyright:](http://choosealicense.com/licenses/mit/) Most basic icon set.
 * [Iconmonstr](http://iconmonstr.com) - [:copyright:](http://iconmonstr.com/license/) A huge selection of icons in SVG and PNG format.
 * [Maps Icon](https://github.com/djaiss/mapsicon) - [:copyright:](https://github.com/djaiss/mapsicon#license) Mapsicon is a free collection of maps for nearly every country in the world, available in 11 different sizes, ranging from 16x16 pixels to 1024x1024 pixels, as well as .svg format.
-* [Material Design Icons](http://www.materialui.co/icons) - A collections of free, material design style icons.
+* [Material Design Icons](http://materialui.co/icons) - A collections of free, material design style icons.
 * [Simple Icons](https://github.com/danleech/simple-icons) - [:copyright:](http://artlibre.org/licence/lal/en/) SVG icons for popular brands.
 * [The Noun Project](https://thenounproject.com/) - [:copyright:](https://thenounproject.com/accounts/pricing/) Over 150,000 icons designed by creators from around the world. Free users must give credit to the creator.
 
@@ -239,7 +239,7 @@ A selection of websites offering color schemes.
 * [Flat UI Color Picker](http://www.flatuicolorpicker.com/) - A copy and paste resource for colors commonly found in 'flat' designs.
 * [Flat UI Colors](https://flatuicolors.com/) - Flat color picker which gives you the perfect colors for flat designs.
 * [LOLColors](http://www.lolcolors.com/) - A nice curated color palette inspiration resource.
-* [Material Design Colors](http://www.materialui.co/colors) - Material ui color palette for Android, Web & iOS.
+* [Material Design Colors](http://materialui.co/colors) - Material ui color palette for Android, Web & iOS.
 * [Material Palette](http://www.materialpalette.com/) - Generate & export your Material Design color palette.
 
 ## Aggregated Content
@@ -249,7 +249,7 @@ A liberal mixture of content aggregated from other free resources and made avail
 * [All The Free Stock](http://allthefreestock.com) - One stop resource for free stock images, videos, sounds and more.
 * [Avopix](https://avopix.com) - More than 15 000 absolutely free stock photos and vectors.
 * [Libre Stock](http://librestock.com/) - Search engine for stock photo websites.
-* [Stock Up](http://www.sitebuilderreport.com/stock-up) - Searching 9,301 (and counting) free stock photos across 25 websites.
+* [Stock Up](https://www.sitebuilderreport.com/stock-up) - Searching 9,301 (and counting) free stock photos across 25 websites.
 * [The Stocks](http://thestocks.im/) - The best royalty free stock photos in one place.
 
 ## HTML Templates
@@ -257,8 +257,8 @@ A liberal mixture of content aggregated from other free resources and made avail
 Various different websites offering free HTML templates and themes.
 
 * [Bootswatch](http://bootswatch.com/) - [:copyright:](https://github.com/thomaspark/bootswatch/blob/gh-pages/LICENSE) Free themes for Bootstrap.
-* [HTML5 Up](http://html5up.net/) - [:copyright:](http://creativecommons.org/licenses/by/3.0/) HTML5 UP makes spiffy HTML5 site templates.
-* [Templated](http://templated.co/) - [:copyright:](http://templated.co/license) A collection of 850 free CSS and HTML5 site templates, designed & built by Cherry + AJ and released under the Creative Commons.
+* [HTML5 Up](https://html5up.net/) - [:copyright:](http://creativecommons.org/licenses/by/3.0/) HTML5 UP makes spiffy HTML5 site templates.
+* [Templated](https://templated.co/) - [:copyright:](https://templated.co/license) A collection of 850 free CSS and HTML5 site templates, designed & built by Cherry + AJ and released under the Creative Commons.
 
 ## Sounds & Music
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ A collection for SVG icon resources which can be used in your interface and webs
 * [Geomicons Icons](http://geomicons.com/) - [:copyright:](http://choosealicense.com/licenses/mit/) Most basic icon set.
 * [Iconmonstr](http://iconmonstr.com) - [:copyright:](http://iconmonstr.com/license/) A huge selection of icons in SVG and PNG format.
 * [Maps Icon](https://github.com/djaiss/mapsicon) - [:copyright:](https://github.com/djaiss/mapsicon#license) Mapsicon is a free collection of maps for nearly every country in the world, available in 11 different sizes, ranging from 16x16 pixels to 1024x1024 pixels, as well as .svg format.
-* [Material Design Icons](http://materialui.co/icons) - A collections of free, material design style icons.
+* [Material Design Icons](https://www.materialui.co/icons) - A collections of free, material design style icons.
 * [Simple Icons](https://github.com/danleech/simple-icons) - [:copyright:](http://artlibre.org/licence/lal/en/) SVG icons for popular brands.
 * [The Noun Project](https://thenounproject.com/) - [:copyright:](https://thenounproject.com/accounts/pricing/) Over 150,000 icons designed by creators from around the world. Free users must give credit to the creator.
 
@@ -239,7 +239,7 @@ A selection of websites offering color schemes.
 * [Flat UI Color Picker](http://www.flatuicolorpicker.com/) - A copy and paste resource for colors commonly found in 'flat' designs.
 * [Flat UI Colors](https://flatuicolors.com/) - Flat color picker which gives you the perfect colors for flat designs.
 * [LOLColors](http://www.lolcolors.com/) - A nice curated color palette inspiration resource.
-* [Material Design Colors](http://materialui.co/colors) - Material ui color palette for Android, Web & iOS.
+* [Material Design Colors](https://www.materialui.co/colors) - Material ui color palette for Android, Web & iOS.
 * [Material Palette](http://www.materialpalette.com/) - Generate & export your Material Design color palette.
 
 ## Aggregated Content


### PR DESCRIPTION
Fixed the 301 (Moved Permanently) links returned by travis/awesome_bot.

The travis log is below. I fixed the 301 ones.

```
  01. [L088] 302 http://www.designerspics.com  → / 
  02. [L093] 301 https://www.morguefile.com/archive  → http://morguefile.com/archive 
  03. [L093] 301 https://www.morguefile.com/terms  → http://morguefile.com/terms 
  04. [L134] 403 http://getrefe.tumblr.com  
  05. [L149] 301 https://facebook.github.io/design/  → http://facebook.design/ 
  06. [L149] 301 https://facebook.github.io/design/disclaimer.html  → http://facebook.design/disclaimer.html 
  07. [L223] 301 http://www.materialui.co/icons  → http://materialui.co/icons 
  08. [L235]  https://www.coleure.com/ SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed 
  09. [L243] 301 http://www.materialui.co/colors  → http://materialui.co/colors 
  10. [L253] 301 http://www.sitebuilderreport.com/stock-up  → https://www.sitebuilderreport.com/stock-up 
  11. [L261] 301 http://html5up.net/  → https://html5up.net/ 
  12. [L262] 301 http://templated.co/  → https://templated.co/ 
  13. [L262] 301 http://templated.co/license  → https://templated.co/license 
  14. [L296] 302 https://www.linkedin.com/shareArticle?mini=true&url=https://github.com/neutraltone/awesome-stock-resources&title=Awesome%20Stock%20Resources&summary=&source=  → https://www.linkedin.com/uas/login?session_redirect=https%3A%2F%2Fwww%2Elinkedin%2Ecom%2FpostLogin%3Fsession_rikey%3Dw-8YoO2IB1Jcnt-UONzL-viqBTByZvZ0Dg2Lb1oJJkcGWx6g62dubSx0i9P7qBtVM2gQ-DD-ikK75NTF8zSL3bltD3gvVgbGWZY%26l%3Dhttps%253A%252F%252Fwww%252Elinkedin%252Ecom%252FshareArticle%253Fsummary%253D%2526mini%253Dtrue%2526source%253D%2526title%253DAwesome%252BStock%252BResources%2526url%253Dhttps%25253A%25252F%25252Fgithub%25252Ecom%25252Fneutraltone%25252Fawesome-stock-resources%26id%3D0%26b%3D5532c871-1d6d-4234-8cc4-6fbb2db49335%26h%3De50S%26m%3DGET 
```