### PR TITLE
Update Pixaroma license and description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ A collection of resources which contain stock graphical elements which don't fit
 * [Freepik](http://www.freepik.com/) - [:copyright:](http://www.freepik.com/terms_of_use) Find free vectors, PSD, icons and photos.
 * [FreeVectors.net](http://www.freeVectors.net) - [:copyright:](http://www.freevectors.net/terms) A fun little community of vector lovers who share free vector graphics.
 * [Logo Dust](http://logodust.com/) - [:copyright:](https://creativecommons.org/licenses/by/4.0/) Free CC Attribution 4.0 logo designs for your projects.
-* [Pixaroma](http://pixaroma.com/) - [:copyright:](http://pixaroma.com/terms-and-conditions/) original logos, icons, characters, illustrations and mobile game designs.
+* [Pixaroma](http://pixaroma.com/) - (license unspecified) original logos, icons, characters, illustrations and mobile game designs, free and premium.
 * [Sketch Repo](https://sketchrepo.com/) - [:copyright:](https://sketchrepo.com/about/) Sketch Repo is a great place to discover Sketch App resources for your next design project.
 * [Vecteezy](https://www.vecteezy.com/) - [:copyright:](https://www.vecteezy.com/terms) Discover & download free vector art from a community of Illustrators.
 


### PR DESCRIPTION
Pixaroma no longer shows terms and conditions or any license on their website. They now do paid content as well.

Fixes #151.