### PR TITLE
Add Visual Hub to Illustrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ These resources haven't specified any formal terms of use or licenses.
 
 A collection of illustration resources which contain a mixture of historical archive, contemporary and public domain assets.
 
+* [Visual Hub](https://visual-hub.net/) - [:copyright:](https://visual-hub.net/en/terms) Free flat-style illustrations for business, education and blogging with no signup required.
 * [Biodiversity Heritage Library](https://www.flickr.com/people/biodivlibrary/) [:copyright:](https://creativecommons.org/publicdomain/mark/1.0/) [:copyright:](https://creativecommons.org/licenses/by/2.0/) A mix of Public Domain and Attribution (CC BY 2.0) licenses. Nearly 150,000 exquisite, historical illustrations of life on Earth.
 * [British Library Illustration Archive](https://www.flickr.com/photos/britishlibrary/albums/72157640831988343/) - [:copyright:](https://www.bl.uk/terms) The British Library’s collections on Flickr Commons offer access to millions of public domain images.
 * [Old Book Illustrations](https://www.oldbookillustrations.com/) - [:copyright:](https://www.oldbookillustrations.com/terms-of-use/) A massive collection of illustrations from old books.


### PR DESCRIPTION
Adding Visual Hub, a free illustration site.

Link: https://visual-hub.net/

Free flat-style illustrations for business documents, education and blogging. All images are free for commercial use, with no attribution and no signup required. The site is available in English, Japanese, Chinese and Korean.
