### PR TITLE
Add Pexafy to Aggregated Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ A liberal mixture of content aggregated from other free resources and made avail
 * [All The Free Stock](https://allthefreestock.com) - One stop resource for free stock images, videos, sounds and more.
 * [Avopix](https://avopix.com) - More than 15 000 absolutely free stock photos and vectors.
 * [Libre Stock](https://librestock.com/) - Search engine for stock photo websites.
+* [Pexafy](https://pexafy.com) - Semantic image search across 9 free stock photo sources, with an API for developers.
 * [Stock Up](https://www.sitebuilderreport.com/stock-up) - Searching 9,301 (and counting) free stock photos across 25 websites.
 * [The Stocks](https://thestocks.im/) - The best royalty free stock photos in one place.
 


### PR DESCRIPTION
Adds Pexafy to the Aggregated Content section.

It searches nine free stock photo sources from one place (Unsplash, Pexels, Pixabay, Kaboompics, Burst, StockSnap, Picjumbo, Skitterphoto, NegativeSpace), matching on a plain-language description of the image rather than on tags. A free tier and a REST API are available.

- Searched the list first: no existing entry for it
- Placed alphabetically between Libre Stock and Stock Up
- Description is short and ends with a full stop
- No attribution label needed: none of the indexed sources require attribution